### PR TITLE
Change clustering to use tree nodes as labels.

### DIFF
--- a/debacl/level_set_tree.py
+++ b/debacl/level_set_tree.py
@@ -357,16 +357,14 @@ class LevelSetTree(object):
         labels : 2-dimensional numpy array
             Each row corresponds to an observation. The first column indicates
             the index of the observation in the original data matrix, and the
-            second column is the integer cluster label (starting at 0). Note
-            that the set of observations in this "foreground" set is typically
-            smaller than the original dataset.
-
-        nodes : list
-            Indices of tree nodes corresponding to foreground clusters.
+            second column is the index of the LST node to which the observation
+            belongs, *with respect to the clustering*. Note that the set of
+            observations in this "foreground" set is typically smaller than the
+            original dataset.
         """
 
         if method == 'leaf':
-            labels, nodes = self._leaf_cluster()
+            labels = self._leaf_cluster()
 
         elif method == 'first-k':
             required = set(['k'])
@@ -375,7 +373,7 @@ class LevelSetTree(object):
                 "cluster labeling method.")
             else:
                 k = kwargs.get('k')
-                labels, nodes = self._first_K_cluster(k)
+                labels = self._first_K_cluster(k)
 
         elif method == 'upper-level-set':
             required = set(['threshold', 'form'])
@@ -385,7 +383,7 @@ class LevelSetTree(object):
             else:
                 threshold = kwargs.get('threshold')
                 form = kwargs.get('form')
-                labels, nodes = self._upper_set_cluster(threshold, form)
+                labels = self._upper_set_cluster(threshold, form)
 
         elif method == 'k-level':
             required = set(['k'])
@@ -394,14 +392,12 @@ class LevelSetTree(object):
                 "cluster labeling method.")
             else:
                 k = kwargs.get('k')
-                labels, nodes = self._first_K_level_cluster(k)
+                labels = self._first_K_level_cluster(k)
 
         else:
             raise ValueError("Cluster labeling method not understood.")
-            labels = _np.array([])
-            nodes = []
 
-        return labels, nodes
+        return labels
 
     def _make_subtree(self, ix):
         """
@@ -542,12 +538,12 @@ class LevelSetTree(object):
         points = []
         cluster = []
 
-        for i, k in enumerate(leaves):
-            points.extend(self.nodes[k].members)
-            cluster += ([i] * len(self.nodes[k].members))
+        for leaf in leaves:
+            points.extend(self.nodes[leaf].members)
+            cluster += ([leaf] * len(self.nodes[leaf].members))
 
         labels = _np.array([points, cluster], dtype=_np.int).T
-        return labels, leaves
+        return labels
 
     def _first_K_cluster(self, k):
         """
@@ -592,13 +588,13 @@ class LevelSetTree(object):
         points = []
         cluster = []
 
-        for i, c in enumerate(nodes):
+        for c in nodes:
             cluster_pts = self.nodes[c].members
             points.extend(cluster_pts)
-            cluster += ([i] * len(cluster_pts))
+            cluster += ([c] * len(cluster_pts))
 
         labels = _np.array([points, cluster], dtype=_np.int).T
-        return labels, nodes
+        return labels
 
     def _upper_set_cluster(self, threshold, form='mass'):
         """
@@ -644,15 +640,15 @@ class LevelSetTree(object):
             points = []
             cluster = []
 
-            for i, c in enumerate(active_nodes):
+            for c in active_nodes:
                 cluster_mask = _np.in1d(upper_level_set,
                                         list(self.nodes[c].members))
                 cluster_pts = upper_level_set[cluster_mask]
                 points.extend(cluster_pts)
-                cluster += ([i] * len(cluster_pts))
+                cluster += ([c] * len(cluster_pts))
 
             labels = _np.array([points, cluster], dtype=_np.int).T
-            return labels, active_nodes
+            return labels
 
     def _first_K_level_cluster(self, k):
         """
@@ -689,14 +685,14 @@ class LevelSetTree(object):
         points = []
         cluster = []
 
-        for i, c in enumerate(nodes):
+        for c in nodes:
 
             cluster_pts = self.nodes[c].members
             points.extend(cluster_pts)
-            cluster += ([i] * len(cluster_pts))
+            cluster += ([c] * len(cluster_pts))
 
         labels = _np.array([points, cluster], dtype=_np.int).T
-        return labels, nodes
+        return labels
 
     def _collapse_leaves(self, active_nodes):
         """

--- a/debacl/test/test_lst.py
+++ b/debacl/test/test_lst.py
@@ -383,7 +383,7 @@ class TestLevelSetTree(unittest.TestCase):
             labels = self.tree.get_clusters(method='fossa')
 
         ## Leaf clustering
-        labels = self.tree.get_clusters(method='leaf')[0]
+        labels = self.tree.get_clusters(method='leaf')
         self._check_cluster_label_plausibility(labels)
         
         leaves = [idx for idx, node in self.tree.nodes.items() 
@@ -392,24 +392,24 @@ class TestLevelSetTree(unittest.TestCase):
 
         ## First-K clusters
         k = 3
-        labels = self.tree.get_clusters(method='first-k', k=k)[0]
+        labels = self.tree.get_clusters(method='first-k', k=k)
         self._check_cluster_label_plausibility(labels)
         self.assertTrue(len(np.unique(labels[:, 1])), k)
 
         ## First level with K clusters
-        labels = self.tree.get_clusters(method='k-level', k=k)[0]
+        labels = self.tree.get_clusters(method='k-level', k=k)
         self._check_cluster_label_plausibility(labels)
         self.assertTrue(len(np.unique(labels[:, 1])), k)
         
         ## Upper set clustering
         labels = self.tree.get_clusters(method='upper-level-set', 
                                         threshold=0.4, 
-                                        form='density')[0]
+                                        form='density')
         self._check_cluster_label_plausibility(labels)
 
         labels = self.tree.get_clusters(method='upper-level-set',
                                         threshold=0.6, 
-                                        form='mass')[0]
+                                        form='mass')
         self._check_cluster_label_plausibility(labels)
 
 

--- a/debacl/test/test_utils.py
+++ b/debacl/test/test_utils.py
@@ -4,6 +4,7 @@ import scipy.special as spspec
 import numpy as np
 from numpy.testing import assert_array_equal
 
+import debacl as dcl
 from debacl import utils as utl
 
 
@@ -248,3 +249,21 @@ class TestBackgroundAssignments(unittest.TestCase):
         """
         """
         pass
+
+
+class TestClusterReindexing(unittest.TestCase):
+    """
+    Make sure the cluster label reindexing works properly.
+    """
+
+    def setUp(self):
+        self.cluster_labels = np.array([[7, 6, 8, 11, 62],
+                                               [3, 3, 7, 7, 4]]).T
+
+    def test_label_reindexing(self):
+        """
+        Test cluster label reindexing.
+        """
+        new_labels = utl.reindex_cluster_labels(self.cluster_labels)
+        assert_array_equal(self.cluster_labels[:, 0], new_labels[:, 0])
+        assert_array_equal(new_labels[:, 1], np.array([0, 0, 2, 2, 1]))

--- a/debacl/utils.py
+++ b/debacl/utils.py
@@ -431,3 +431,41 @@ def assign_background_points(X, clusters, method=None, k=1):
     return labels
 
 
+def reindex_cluster_labels(labels):
+    """
+    Reindex integer cluster labels to be consecutive non-negative integers.
+    This is useful because the `LevelSetTree.get_clusters` method returns
+    cluster labels that match level set tree node indices. These are generally
+    not consecutive whole numbers.
+
+    Parameters
+    ----------
+    labels : numpy.array
+        Cluster labels returned from the `LevelSetTree.get_clusters` method.
+        The first column should be row indices and the second column should be
+        integers corresponding to ID numbers of nodes in the level set tree.
+
+    Returns
+    -------
+    new_labels : numpy.array
+        Cluster labels in the same form of the input 'labels', but with cluster
+        labels reindexed to be consecutive non-negative integers.
+    """
+
+    if not isinstance(labels, _np.ndarray):
+        raise TypeError("Input 'labels' must be a numpy array.")
+
+    if labels.ndim != 2:
+        raise TypeError("Input 'labels' must be a 2-dimensional numpy array.")
+
+    if labels.shape[1] != 2:
+        raise TypeError("Input 'labels' must have two columns.")
+
+    if not issubclass(labels.dtype.type, _np.integer):
+        raise TypeError("Input 'labels' must contain integers.")
+
+    unique_labels = _np.unique(labels[:, 1])
+    label_map = {v: k for k, v in enumerate(unique_labels)}
+    new_labels = map(lambda x: label_map[x], labels[:, 1])
+    new_labels = _np.vstack((labels[:, 0], new_labels)).T
+    return new_labels


### PR DESCRIPTION
- Previously used consecutive integers.
- Clustering now returns only one object, the numpy array mapping
  row index of an instance to its assigned cluster label.
- Add a utility to reindex to get consecutive integers if needed.
- Unit test the new utility.