### PR TITLE
Hide __future__ imports from the debacl namespaces.

### DIFF
--- a/debacl/level_set_tree.py
+++ b/debacl/level_set_tree.py
@@ -6,7 +6,8 @@ analysis and clustering with level set trees.
 """
 
 ## Built-in packages
-from __future__ import print_function, absolute_import
+from __future__ import print_function as _print_function
+from __future__ import absolute_import as _absolute_import
 
 import logging as _logging
 import copy as _copy

--- a/debacl/test/test_lst.py
+++ b/debacl/test/test_lst.py
@@ -1,5 +1,6 @@
 
-from __future__ import print_function, absolute_import
+from __future__ import print_function as _print_function
+from __future__ import absolute_import as _absolute_import
 
 import os
 import unittest

--- a/debacl/test/test_utils.py
+++ b/debacl/test/test_utils.py
@@ -1,5 +1,6 @@
 
-from __future__ import print_function, absolute_import
+from __future__ import print_function as _print_function
+from __future__ import absolute_import as _absolute_import
 
 import unittest
 import scipy.special as spspec

--- a/debacl/utils.py
+++ b/debacl/utils.py
@@ -3,7 +3,8 @@ General utility functions for the DEnsity-BAsed CLustering (DeBaCl) toolbox.
 """
 
 ## Required packages
-from __future__ import print_function, absolute_import
+from __future__ import print_function as _print_function
+from __future__ import absolute_import as _absolute_import
 
 try:
     import numpy as _np


### PR DESCRIPTION
It's annoying to see stray `print_function` and `absolute_import` in the DeBaCl namespaces, so these are now imported silently.