### PR TITLE
Added functionality to allow X to be a precomputed distance matrix

### DIFF
--- a/debacl/level_set_tree.py
+++ b/debacl/level_set_tree.py
@@ -1300,10 +1300,8 @@ def construct_tree_from_precomputed_matrix(X, p, k, prune_threshold=None, num_le
     Examples
     --------
     >>> X = numpy.random.rand(100, 2)
-    >>> @numpy.vectorize
-    >>> def euclidean(i,j):
-    >>>     return scipy.spatial.distance.euclidean(X[i], X[j])
-    >>> X = numpy.fromfunction(euclidean, (100,100))
+    >>> X = scipy.spatial.distance.pdist(data)
+    >>> X = scipy.spatial.distance.squareform(matrix)
     >>> tree = debacl.construct_tree_from_precomputed_matrix(X, p=2, k=8, prune_threshold=5)
     >>> print(tree)
     +----+-------------+-----------+------------+----------+------+--------+----------+


### PR DESCRIPTION
This is useful if the distance metric is expensive to calculate and the user wants to speed up multiple runs of DeBaCl by pre-calculating the distance matrix and inputting precomputed values.

In addition, in some uncommon cases, data may not be easily represented in N dimensional space but distance values for the data may be readily available. This code provides functionality for these less common use cases.

Scikit-learn provides this functionality for many of it's methods, as does Leland McInnes's hdbscan library. I use these libraries regularly and have found the precomputed option quite useful.

I would be happy to explain anything that isn't clear enough, and I hope the code is written to be as computationally inexpensive as possible.