### PR TITLE
MIGRATION: Python 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ MANIFEST
 *.pyc
 *.lst
 examples/.ipynb_checkpoints
+.vscode/

--- a/debacl/level_set_tree.py
+++ b/debacl/level_set_tree.py
@@ -1039,8 +1039,8 @@ class LevelSetTree(object):
 
                 segmap += branch_segmap
                 splitmap += branch_splitmap
-                splits = dict(splits.items() + branch_splits.items())
-                segments = dict(segments.items() + branch_segs.items())
+                splits = dict(list(splits.items()) + list(branch_splits.items()))
+                segments = dict(list(segments.items()) + list(branch_segs.items()))
 
             ## find the middle of the children's x-position and make vertical
             #  segment ix
@@ -1183,8 +1183,8 @@ class LevelSetTree(object):
 
                 segmap += branch_segmap
                 splitmap += branch_splitmap
-                splits = dict(splits.items() + branch_splits.items())
-                segments = dict(segments.items() + branch_segs.items())
+                splits = dict(list(splits.items()) + list(branch_splits.items()))
+                segments = dict(list(segments.items()) + list(branch_segs.items()))
 
             ## find the middle of the children's x-position and make vertical
             ## segment ix

--- a/debacl/test/test_lst.py
+++ b/debacl/test/test_lst.py
@@ -134,8 +134,8 @@ class TestLSTConstructors(unittest.TestCase):
         ans_end_levels = [0.104, 0.189, 1.001, 0.345, 0.741, 0.508, 0.381,
                           0.862, 0.804, 1.349, 1.004]
 
-        self.assertItemsEqual(start_levels, ans_start_levels)
-        self.assertItemsEqual(end_levels, ans_end_levels)
+        self.assertCountEqual(start_levels, ans_start_levels)
+        self.assertCountEqual(end_levels, ans_end_levels)
 
         ## Masses
         start_masses = [round(node.start_mass, 3)
@@ -148,8 +148,8 @@ class TestLSTConstructors(unittest.TestCase):
         ans_end_masses = [0.018, 0.079, 0.947, 0.293, 0.667, 0.473, 0.359,
                           0.816, 0.734, 1.0, 0.949]
 
-        self.assertItemsEqual(start_masses, ans_start_masses)
-        self.assertItemsEqual(end_masses, ans_end_masses)
+        self.assertCountEqual(start_masses, ans_start_masses)
+        self.assertCountEqual(end_masses, ans_end_masses)
 
         ## Sizes and parents
         sizes = [len(node.members) for node in tree.nodes.values()]
@@ -158,8 +158,8 @@ class TestLSTConstructors(unittest.TestCase):
         ans_sizes = [1000, 767, 215, 238, 472, 76, 23, 231, 12, 103, 48]
         ans_parents = [None, 0, 0, 1, 1, 3, 3, 4, 4, 7, 7]
 
-        self.assertItemsEqual(sizes, ans_sizes)
-        self.assertItemsEqual(parents, ans_parents)
+        self.assertCountEqual(sizes, ans_sizes)
+        self.assertCountEqual(parents, ans_parents)
 
     def test_construct_from_graph(self):
         """
@@ -262,7 +262,7 @@ class TestBackwardCompatibility(unittest.TestCase):
             self.assertEqual(len(partition[:, 0]),
                              len(np.unique(partition[:, 0])))
             self.assertEqual(np.min(partition[:, 0]), 0)
-            self.assertItemsEqual(np.unique(partition[:, 1]),
+            self.assertCountEqual(np.unique(partition[:, 1]),
                                   tree.nodes.keys())
 
             # save and load
@@ -270,7 +270,7 @@ class TestBackwardCompatibility(unittest.TestCase):
                 tree.save(t.name)
                 tree2 = dcl.load_tree(t.name)
 
-                self.assertItemsEqual(
+                self.assertCountEqual(
                     [x.start_level for x in tree.nodes.values()],
                     [y.start_level for y in tree2.nodes.values()])
 
@@ -481,7 +481,7 @@ class TestLevelSetTree(unittest.TestCase):
         leaves = [idx for idx, node in self.tree.nodes.items()
                   if len(node.children) == 0]
 
-        self.assertItemsEqual(np.unique(leaf_labels[:, 1]), leaves)
+        self.assertCountEqual(np.unique(leaf_labels[:, 1]), leaves)
 
         ## Check that background filling works correctly.
         full_labels = self.tree.get_clusters(method='leaf',
@@ -519,5 +519,5 @@ class TestLevelSetTree(unittest.TestCase):
         self.assertEqual(np.min(partition[:, 0]), 0)
 
         # Labels should match tree nodes exactly.
-        self.assertItemsEqual(np.unique(partition[:, 1]),
+        self.assertCountEqual(np.unique(partition[:, 1]),
                               self.tree.nodes.keys())

--- a/debacl/test/test_utils.py
+++ b/debacl/test/test_utils.py
@@ -77,7 +77,7 @@ class TestSimilarityGraphs(unittest.TestCase):
             assert_array_equal(radii, ans_radii)
 
             for neighbors, ans_neighbors in zip(knn, ans_graph):
-                self.assertItemsEqual(neighbors, ans_neighbors)
+                self.assertCountEqual(neighbors, ans_neighbors)
 
     def test_epsilon_graph(self):
         """
@@ -95,7 +95,7 @@ class TestSimilarityGraphs(unittest.TestCase):
         enn = utl.epsilon_graph(self.X, epsilon)
 
         for neighbors, ans_neighbors in zip(enn, ans_graph):
-            self.assertItemsEqual(neighbors, ans_neighbors)
+            self.assertCountEqual(neighbors, ans_neighbors)
 
 
 class TestDensityGrids(unittest.TestCase):
@@ -179,7 +179,7 @@ class TestDensityGrids(unittest.TestCase):
 
         ## Test uniform input.
         levels = utl.define_density_mass_grid(self.uniform_density)
-        self.assertItemsEqual(levels, [1.])
+        self.assertCountEqual(levels, [1.])
 
     def _check_level_grid_answer(self, density, levels):
         """
@@ -226,7 +226,7 @@ class TestDensityGrids(unittest.TestCase):
 
         ## Uniform input should have a single value.
         levels = utl.define_density_level_grid(self.uniform_density)
-        self.assertItemsEqual(levels, [1.])
+        self.assertCountEqual(levels, [1.])
 
 
 class TestClusterReindexing(unittest.TestCase):

--- a/debacl/utils.py
+++ b/debacl/utils.py
@@ -484,6 +484,6 @@ def reindex_cluster_labels(labels):
 
     unique_labels = _np.unique(labels[:, 1])
     label_map = {v: k for k, v in enumerate(unique_labels)}
-    new_labels = map(lambda x: label_map[x], labels[:, 1])
-    new_labels = _np.vstack((labels[:, 0], new_labels)).T
+    new_labels = list(map(lambda x: label_map[x], labels[:, 1]))
+    new_labels = _np.vstack([labels[:, 0], new_labels]).T
     return new_labels


### PR DESCRIPTION
This makes the package compatible with Python 3. I changed the following:

  - Use of `dict.items()` instead of `dict.iteritems()` (same for keys and values)
  - Subgraphs are now not "freezed" anymore when using a more recent version of networkx (solves issue #67 )
  - Explicite use of "latin1" encoding when unpickling with `load_tree`
  - Use of `assertCountEqual` instead of `assertItemsEqual` in the tests
  - Use of `list()` to exhaust `map` generator and to convert `dict.values` to NumPy array

All tests pass (with Python 3.8) and the quickstart example from the documentation works as expected.